### PR TITLE
fix: escape reserved words

### DIFF
--- a/src/assemblyscript/common.rs
+++ b/src/assemblyscript/common.rs
@@ -38,7 +38,7 @@ pub trait Normalize {
     }
 
     fn as_var(&self) -> String {
-        self.as_str().to_case(Case::Snake)
+        escape_reserved_word(&self.as_str().to_case(Case::Snake))
     }
 
     fn as_const(&self) -> String {
@@ -108,3 +108,66 @@ impl ToLanguageRepresentation for ASType {
         self
     }
 }
+
+pub fn escape_reserved_word(word: &str) -> String {
+    if RESERVED.iter().any(|k| *k == word) {
+        // If the camel-cased string matched any strict or reserved keywords, then
+        // append a trailing underscore to the identifier we generate.
+        format!("{}_", word)
+    } else {
+        word.to_string() // Otherwise, use the string as is.
+    }
+}
+
+/// Reserved Keywords.
+/// 
+/// Source: [ECMAScript 2022 Language Specification](https://tc39.es/ecma262/#sec-keywords-and-reserved-words)
+const RESERVED: &[&str] = &[
+    "await",
+    "break",
+    "case",
+    "catch",
+    "class",
+    "const",
+    "continue",
+    "debugger",
+    "default",
+    "delete",
+    "do",
+    "else",
+    "enum",
+    "export",
+    "extends",
+    "false",
+    "finally",
+    "for",
+    "function",
+    "if",
+    "import",
+    "in",
+    "instanceof",
+    "new",
+    "null",
+    "return",
+    "super",
+    "switch",
+    "this",
+    "throw",
+    "true",
+    "try",
+    "typeof",
+    "var",
+    "void",
+    "while",
+    "with",
+    "yield",
+    "let",
+    "static",
+    "implements",
+    "interface",
+    "package",
+    "private",
+    "protected",
+    "and",
+    "public",
+];

--- a/src/rust/common.rs
+++ b/src/rust/common.rs
@@ -30,15 +30,15 @@ pub trait Normalize {
     }
 
     fn as_fn(&self) -> String {
-        self.as_str().to_case(Case::Snake)
+        escape_reserved_word(&self.as_str().to_case(Case::Snake))
     }
 
     fn as_fn_suffix(&self) -> String {
-        self.as_str().to_case(Case::Snake)
+        escape_reserved_word(&self.as_str().to_case(Case::Snake))
     }
 
     fn as_var(&self) -> String {
-        self.as_str().to_case(Case::Snake)
+        escape_reserved_word(&self.as_str().to_case(Case::Snake))
     }
 
     fn as_const(&self) -> String {
@@ -108,3 +108,39 @@ impl ToLanguageRepresentation for ASType {
         self
     }
 }
+
+/// Checks the given word against a list of reserved keywords. 
+/// If the given word conflicts with a keyword, a trailing underscore will be appended.
+/// 
+/// Adapted from [wiggle](https://docs.rs/wiggle/latest/wiggle/index.html)
+pub fn escape_reserved_word(word: &str) -> String {
+    if STRICT.iter().chain(RESERVED).any(|k| *k == word) {
+        // If the camel-cased string matched any strict or reserved keywords, then
+        // append a trailing underscore to the identifier we generate.
+        format!("{}_", word)
+    } else {
+        word.to_string() // Otherwise, use the string as is.
+    }
+}
+
+/// Strict keywords.
+///
+/// Source: [The Rust Reference][https://doc.rust-lang.org/reference/keywords.html#strict-keywords]
+const STRICT: &[&str] = &[
+    "as", "async", "await", "break", "const", "continue", "crate", "dyn", "else", "enum", "extern",
+    "false", "fn", "for", "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub",
+    "ref", "return", "self", "Self", "static", "struct", "super", "trait", "true", "type",
+    "unsafe", "use", "where", "while",
+];
+
+/// Reserved keywords.
+/// 
+/// These keywords aren't used yet, but they are reserved for future use. They have the same
+/// restrictions as strict keywords. The reasoning behind this is to make current programs
+/// forward compatible with future versions of Rust by forbidding them to use these keywords.
+///
+/// Source: [The Rust Reference](https://doc.rust-lang.org/reference/keywords.html#reserved-keywords)
+const RESERVED: &[&str] = &[
+    "abstract", "become", "box", "do", "final", "macro", "override", "priv", "try", "typeof",
+    "unsized", "virtual", "yield",
+];

--- a/src/zig/common.rs
+++ b/src/zig/common.rs
@@ -38,7 +38,7 @@ pub trait Normalize {
     }
 
     fn as_var(&self) -> String {
-        self.as_str().to_case(Case::Snake)
+        escape_reserved_word(&self.as_str().to_case(Case::Snake))
     }
 
     fn as_const(&self) -> String {
@@ -106,3 +106,70 @@ impl ToLanguageRepresentation for ASType {
         self
     }
 }
+
+/// Checks the given word against a list of reserved keywords. 
+/// If the given word conflicts with a keyword, a trailing underscore will be appended.
+pub fn escape_reserved_word(word: &str) -> String {
+    if RESERVED.iter().any(|k| *k == word) {
+        // If the camel-cased string matched any strict or reserved keywords, then
+        // append a trailing underscore to the identifier we generate.
+        format!("{}_", word)
+    } else {
+        word.to_string() // Otherwise, use the string as is.
+    }
+}
+
+/// Reserved Keywords.
+/// 
+/// Source: [Zig Language Reference](https://ziglang.org/documentation/master/#toc-Keyword-Reference)
+const RESERVED: &[&str] = &[
+    "align",
+    "allowzero",
+    "and",
+    "anyframe",
+    "anytype",
+    "asm",
+    "async",
+    "await",
+    "break",
+    "catch",
+    "comptime",
+    "const",
+    "continue",
+    "defer",
+    "else",
+    "enum",
+    "errdefer",
+    "error",
+    "export",
+    "extern",
+    "false",
+    "fn",
+    "for",
+    "if",
+    "inline",
+    "noalias",
+    "nosuspend",
+    "null",
+    "or",
+    "orelse",
+    "packed",
+    "pub",
+    "resume",
+    "return",
+    "linksection",
+    "struct",
+    "suspend",
+    "switch",
+    "test",
+    "threadlocal",
+    "true",
+    "try",
+    "undefined",
+    "union",
+    "unreachable",
+    "usingnamespace",
+    "var",
+    "volatile",
+    "while",
+];


### PR DESCRIPTION
This checks against a list of reserved words for every language and appends a trailing underscore to escape an conflicting variable names.